### PR TITLE
Refactor validation results file path to include output directory

### DIFF
--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
@@ -7,6 +7,7 @@ import os
 from typing import Optional
 
 from snowflake.snowpark_checkpoints.utils.constant import (
+    SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
     VALIDATION_RESULTS_JSON_FILE_NAME,
 )
 from snowflake.snowpark_checkpoints.validation_results import (
@@ -52,7 +53,11 @@ class ValidationResultsMetadata:
         validation_results_file = (
             path
             if path is not None
-            else os.path.join(os.getcwd(), VALIDATION_RESULTS_JSON_FILE_NAME)
+            else os.path.join(
+                os.getcwd(),
+                SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
+                VALIDATION_RESULTS_JSON_FILE_NAME,
+            )
         )
 
         self.validation_results = ValidationResults(results=[])
@@ -91,7 +96,9 @@ class ValidationResultsMetadata:
 
         """
         validation_results_file = os.path.join(
-            os.getcwd(), VALIDATION_RESULTS_JSON_FILE_NAME
+            os.getcwd(),
+            SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
+            VALIDATION_RESULTS_JSON_FILE_NAME,
         )
 
         with open(validation_results_file, "w") as output_file:


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1876763](https://snowflakecomputing.atlassian.net/browse/SNOW-1876763)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

### Description
This pull request includes changes to the `snowpark-checkpoints-validators` to enhance the directory structure for validation results. The changes primarily involve updating the paths used for loading and saving validation results.

Directory structure improvements:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1R10): Imported `SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME` from constants.
* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L55-R60): Modified the `_load` method to include `SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME` in the path when `path` is not provided.
* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L94-R101): Updated the `save` method to include `SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME` in the path for saving validation results.

### How Has This Been Tested?
* Ran the demos files, they generate the correct output files.

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [X] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-1876763]: https://snowflakecomputing.atlassian.net/browse/SNOW-1876763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ