### PR TITLE
SNOW-1880200: Add @functools.wraps decorator to telemetry report function for better function metadata preservation

### DIFF
--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py
@@ -9,6 +9,7 @@ import json
 import os
 
 from enum import IntEnum
+from functools import wraps
 from os import getcwd, getenv, makedirs
 from pathlib import Path
 from platform import python_version
@@ -586,6 +587,7 @@ def report_telemetry(
     def report_telemetry_decorator(func):
         func_name = func.__name__
 
+        @wraps(func)
         def wrapper(*args, **kwargs):
             func_exception = None
             result = None


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1880200](https://snowflakecomputing.atlassian.net/browse/SNOW-1880200)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->
Sphinx cannot generated correctly the documentation of the functions decorated with `@report_telemetry`. Specifically, the function arguments and docstrings are not right.

For example, this is how the documentation looks like for the `check_output_schema` function:
<img width="1403" alt="Screenshot 2025-01-13 at 10 04 40 AM" src="https://github.com/user-attachments/assets/6243f005-98d1-458d-8a9a-6a9a02502fe6" />

### Description
This pull request adds the `wraps` decorator to the `report_telemetry_decorator` function to preserve the original function's metadata. To learn more about this, you can check [[1]](https://openmdao.org/newdocs/versions/latest/other_useful_docs/developer_docs/sphinx_decorators.html) and [[2]](https://docs.python.org/3/library/functools.html#functools.wraps).

After this change, the documentation for those functions is generated correctly:
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/88726700-8692-41c7-aafb-77b92acd86b7" />

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any screenshots that are relevant. -->
No new tests were added. The current test should pass as usual.

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.
### Review & Approval Requests
<!--- Use this section to request review and approval from specific individuals. -->
<!--- Include any relevant instructions for each reviewer and approver. -->

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-1880200]: https://snowflakecomputing.atlassian.net/browse/SNOW-1880200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ