### PR TITLE
SNOW-1888478: Enhance checkpoint functionality by adding output path parameter and improving validation results directory handling

### DIFF
--- a/Demos/pyspark/demo_pyspark_pipeline_dataframe.py
+++ b/Demos/pyspark/demo_pyspark_pipeline_dataframe.py
@@ -264,7 +264,10 @@ df = spark.createDataFrame(data, schema)
 
 # Collect a schema/stats here!
 collect_dataframe_checkpoint(
-    df, "demo_initial_creation_checkpoint_dataframe", mode=CheckpointMode.DATAFRAME
+    df,
+    "demo_initial_creation_checkpoint_dataframe",
+    mode=CheckpointMode.DATAFRAME,
+    output_path="Demos/snowpark",
 )
 
 df1 = df.withColumn(
@@ -276,5 +279,8 @@ df1 = df.withColumn(
 
 # Collect a schema/stats here!
 collect_dataframe_checkpoint(
-    df1, "demo_add_a_column_dataframe", mode=CheckpointMode.DATAFRAME
+    df1,
+    "demo_add_a_column_dataframe",
+    mode=CheckpointMode.DATAFRAME,
+    output_path="Demos/snowpark",
 )

--- a/Demos/snowpark/demo_snowpark_pipeline_dataframe.py
+++ b/Demos/snowpark/demo_snowpark_pipeline_dataframe.py
@@ -272,6 +272,7 @@ validate_dataframe_checkpoint(
     "demo_initial_creation_checkpoint_dataframe",
     job_context=job_context,
     mode=CheckpointMode.DATAFRAME,
+    output_path="Demos/snowpark",
 )
 
 
@@ -312,4 +313,5 @@ validate_dataframe_checkpoint(
     "demo_add_a_column_dataframe",
     job_context=job_context,
     mode=CheckpointMode.DATAFRAME,
+    output_path="Demos/snowpark",
 )

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
@@ -51,11 +51,14 @@ class ValidationResultsMetadata:
             Exception: If there is an error reading the validation results file.
 
         """
-        dir_path = path if path else os.getcwd()
+        self.validation_results_directory = path if path else os.getcwd()
+        self.validation_results_directory = os.path.join(
+            self.validation_results_directory,
+            SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
+        )
 
         self.validation_results_file = os.path.join(
-            dir_path,
-            SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
+            self.validation_results_directory,
             VALIDATION_RESULTS_JSON_FILE_NAME,
         )
 
@@ -84,18 +87,18 @@ class ValidationResultsMetadata:
         self.validation_results.results.append(validation_result)
 
     def save(self):
-        """Save the validation results to a JSON file.
+        """Save the validation results to a file.
 
-        The file is saved in the current working directory with a predefined
-        file name. The validation results are serialized using the
-        ValidationResultEncoder.
+        This method checks if the directory specified by validation results directory
+        exists, and if not, it creates the directory. Then, it writes the validation results
+        to a file specified by validation results file in JSON format.
 
         Raises:
-            OSError: If the file cannot be opened or written to.
+            OSError: If the directory cannot be created or the file cannot be written.
 
         """
-        if not os.path.exists(SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME):
-            os.makedirs(SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME)
+        if not os.path.exists(self.validation_results_directory):
+            os.makedirs(self.validation_results_directory)
 
         with open(self.validation_results_file, "w") as output_file:
             output_file.write(self.validation_results.model_dump_json())


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1888478](https://snowflakecomputing.atlassian.net/browse/SNOW-1888478)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

### Description
<!--- Describe your changes in detail. Link documentation if applicable. -->
This pull request includes several changes to improve the handling of validation results and add output paths to checkpoint functions in the PySpark and Snowpark demo pipelines. The most important changes include adding the `output_path` parameter to the checkpoint functions, updating the validation results directory handling, and adding unit tests for the new functionality.

Enhancements to checkpoint functions:

* [`Demos/pyspark/demo_pyspark_pipeline_dataframe.py`](diffhunk://#diff-699ea228c8a1602060543916080acba41e47a93602cd6c0d8ab7b12e37c1e88fL267-R270): Added `output_path` parameter to `collect_dataframe_checkpoint` calls for better output management. [[1]](diffhunk://#diff-699ea228c8a1602060543916080acba41e47a93602cd6c0d8ab7b12e37c1e88fL267-R270) [[2]](diffhunk://#diff-699ea228c8a1602060543916080acba41e47a93602cd6c0d8ab7b12e37c1e88fL279-R285)
* [`Demos/snowpark/demo_snowpark_pipeline_dataframe.py`](diffhunk://#diff-318988a4d44983ba4d07ecab4e9c88e04e48925721abf117b22136da8be78f23R275): Added `output_path` parameter to `collect_dataframe_checkpoint` calls for better output management. [[1]](diffhunk://#diff-318988a4d44983ba4d07ecab4e9c88e04e48925721abf117b22136da8be78f23R275) [[2]](diffhunk://#diff-318988a4d44983ba4d07ecab4e9c88e04e48925721abf117b22136da8be78f23R316)

Improvements to validation results handling:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L54-R61): Updated `_load` method to set the `validation_results_directory` and ensure the directory exists before saving validation results. [[1]](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L54-R61) [[2]](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L87-R101)

Unit tests for validation results:

* [`snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py`](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aR3): Added unit tests to verify the correct behavior of the `save` method, including directory creation and file writing. [[1]](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aR3) [[2]](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aR88-R123)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any screenshots that are relevant. -->
- [x] Unit tests
- [x] Integration tests
- [x] Ran the PySpark and Snowpark demo pipelines

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-1888478]: https://snowflakecomputing.atlassian.net/browse/SNOW-1888478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ