### PR TITLE
SNOW-1890314: Implement Singleton pattern for ValidationResultsMetadata class

### DIFF
--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/singleton.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/singleton.py
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2012-2024 Snowflake Computing Inc. All rights reserved.
+#
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
@@ -6,6 +6,7 @@ import os
 
 from typing import Optional
 
+from snowflake.snowpark_checkpoints.singleton import Singleton
 from snowflake.snowpark_checkpoints.utils.constants import (
     SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
     VALIDATION_RESULTS_JSON_FILE_NAME,
@@ -16,7 +17,7 @@ from snowflake.snowpark_checkpoints.validation_results import (
 )
 
 
-class ValidationResultsMetadata:
+class ValidationResultsMetadata(metaclass=Singleton):
 
     """ValidationResultsMetadata is a class that manages the loading, storing, and updating of validation results.
 

--- a/snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py
+++ b/snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import mock_open, patch
-from unittest.mock import mock_open, patch, MagicMock
+from pytest import fixture
+from snowflake.snowpark_checkpoints.singleton import Singleton
 from snowflake.snowpark_checkpoints.utils.constants import (
     PASS_STATUS,
     SNOWPARK_CHECKPOINTS_OUTPUT_DIRECTORY_NAME,
@@ -13,6 +14,11 @@ from snowflake.snowpark_checkpoints.validation_results import (
     ValidationResult,
     ValidationResults,
 )
+
+
+@fixture(autouse=True)
+def singleton():
+    Singleton._instances = {}
 
 
 def test_load_with_valid_file():


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1890314](https://snowflakecomputing.atlassian.net/browse/SNOW-1890314)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

### Description
<!--- Describe your changes in detail. Link documentation if applicable. -->
This pull request introduces a Singleton pattern to the `snowpark-checkpoints-validators` project and updates the `ValidationResultsMetadata` class to use this pattern. Additionally, it includes changes to the unit tests to accommodate the new Singleton implementation.

### Introduction of Singleton Pattern:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/singleton.py`](diffhunk://#diff-b13fd2a648b98e6c338b96651c40cac5de64833229b834855bfdf6445b6d96dfR1-R12): Added a new `Singleton` class to implement the Singleton pattern.

### Updates to `ValidationResultsMetadata`:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1L19-R20): Modified the `ValidationResultsMetadata` class to use the `Singleton` metaclass.
* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1R9): Imported the `Singleton` class.

### Unit Test Adjustments:

* [`snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py`](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aR19-R23): Added a pytest fixture to reset the Singleton instances before each test.
* [`snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py`](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aL3-R4): Imported the `Singleton` class and `fixture` from `pytest`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any screenshots that are relevant. -->
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-1890314]: https://snowflakecomputing.atlassian.net/browse/SNOW-1890314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ