### PR TITLE
SNOW-1890482 New telemetry validation in the E2E test added

### DIFF
--- a/snowpark-checkpoints-testing/src/utils/validations.py
+++ b/snowpark-checkpoints-testing/src/utils/validations.py
@@ -23,7 +23,11 @@ from src.utils.constants import (
     EXECUTION_MODE_COLUMN_NAME,
     DATE_COLUMN_NAME,
 )
-
+MESSAGE_VALUE= "message"
+EVENT_NAME_VALUE = "event_name"
+TYPE_VALUE = "type"
+METADATA_VALUE = "metadata"
+DATA_VALUE = "data"
 JOB_NAME = "E2E_Test"
 REGEX_JSON_TELEMETRY = r"^(.*)(telemetry_info)(.*)(json)$"
 expected_data = {
@@ -223,29 +227,29 @@ def validate_telemetry_data(execution_mode: CheckpointMode) -> None:
     5. Iterates through each telemetry file and compares its contents with the expected data.
     6. Asserts that the event name, snowpark checkpoints version, event type, and event data match the expected values.
     """
-    ruta = os.getcwd()
-    pat = re.compile(REGEX_JSON_TELEMETRY, re.I)
-    resultado = []
-    for dir, _, archivos in os.walk(ruta):
-        resultado.extend(
-            [os.path.join(dir, arch) for arch in filter(pat.search, archivos)]
+    path = os.getcwd()
+    pattern = re.compile(REGEX_JSON_TELEMETRY, re.I)
+    resul = []
+    for dir, _, files in os.walk(path):
+        resul.extend(
+            [os.path.join(dir, file) for file in filter(pattern.search, files)]
         )
-    resultado.sort()
-    for cont in range(len(resultado)):
-        file = resultado[cont]
-        data_expected = data_expected_telemetry[execution_mode.value][cont]
+    resul.sort()
+    for count in range(len(resul)):
+        file = resul[count]
+        data_expected = data_expected_telemetry[execution_mode.value][count]
         with open(file, "r") as file:
             data = json.load(file)
             assert (
-                data["message"]["event_name"] == data_expected["event_name"]
+                data[MESSAGE_VALUE][EVENT_NAME_VALUE] == data_expected[EVENT_NAME_VALUE]
             ), "Telemetry: The event name is not correct"
             assert (
-                data["message"]["metadata"]["snowpark_checkpoints_version"]
+                data[MESSAGE_VALUE][METADATA_VALUE]["snowpark_checkpoints_version"]
                 == get_version()
             ), "Telemetry: The snowpark checkpoints version is not correct"
             assert (
-                data["message"]["type"] == data_expected["type"]
+                data[MESSAGE_VALUE][TYPE_VALUE] == data_expected[TYPE_VALUE]
             ), "Telemetry: The event type is not correct"
             assert (
-                data["message"]["data"] == data_expected["data"]
+                data[MESSAGE_VALUE][DATA_VALUE] == data_expected[DATA_VALUE]
             ), "Telemetry: The event data is not correct"


### PR DESCRIPTION
### Motivation & Context

JIRA: SNOW-1890482

New telemetry validation added in the E2E test

### Description
This pull request introduces several changes to the `snowpark-checkpoints-testing` project, focusing on enhancing telemetry validation. The most important changes include updating the end-to-end tests to validate telemetry data.

### Telemetry Validation Enhancements:

* [`snowpark-checkpoints-testing/src/utils/validations.py`](diffhunk://#diff-d370508b1685b60acf5ed472ffa8d7dca6ed6eb10374c02e664edf5bbee3041fR5-R14): Added a new function `validate_telemetry_data` to validate telemetry data files against expected data for a given execution mode. 

### End-to-End Test Updates:

* [`snowpark-checkpoints-testing/test/e2e/test_e2e_checkpoints.py`](diffhunk://#diff-fc7938d7ce28d62ea0fba23a16dddb1720537e19a1aa9020b75eca96e51a854fR24): Updated the end-to-end test function `test_e2e_checkpoints` to include validation of telemetry data. Added the import for the new `validate_telemetry_data` function.

### How Has This Been Tested?
Run the new automated tests

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [x] Other (New telemetry validation added)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.
