### PR TITLE
SNOW-1902978: Add clean method to ValidationResultsMetadata and update validation result handling

### DIFF
--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/utils_checks.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/utils_checks.py
@@ -359,6 +359,8 @@ def _update_validation_result(
 
     pipeline_result_metadata = ValidationResultsMetadata(output_path)
 
+    pipeline_result_metadata.clean()
+
     pipeline_result_metadata.add_validation_result(
         ValidationResult(
             timestamp=datetime.now().isoformat(),

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py
@@ -88,6 +88,15 @@ class ValidationResultsMetadata(metaclass=Singleton):
                         f"Error reading validation results file: {self.validation_results_file} \n {e}"
                     ) from None
 
+    def clean(self):
+        """Clean the validation results list.
+
+        This method empties the validation results list.
+
+        """
+        if not os.path.exists(self.validation_results_file):
+            self.validation_results.results = []
+
     def add_validation_result(self, validation_result: ValidationResult):
         """Add a validation result to the pipeline result list.
 


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1902978](https://snowflakecomputing.atlassian.net/browse/SNOW-1902978)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

### Description
<!--- Describe your changes in detail. Link documentation if applicable. -->
This pull request introduces a new method to clean validation results and includes corresponding updates to the validation process and unit tests. The most important changes include adding the `clean` method to the `ValidationResultsMetadata` class and updating the `_update_validation_result` function to use this new method.

### Changes to validation process:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/utils_checks.py`](diffhunk://#diff-31f5613a1d13e3aa3bceb776d60e944aa9b6c2c59f569aa62e747e36b07d8610R362-R363): Updated the `_update_validation_result` function to call the new `clean` method before adding a new validation result.

### New method addition:

* [`snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/validation_result_metadata.py`](diffhunk://#diff-f72b1df9ef1eb6fc59875ca7a47b5b19bb66f02733e27deeaf909c45d32ae4f1R91-R99): Added the `clean` method to the `ValidationResultsMetadata` class to empty the validation results list if the results file does not exist.

### Unit tests:

* [`snowpark-checkpoints-validators/test/unit/test_validation_result_metadata.py`](diffhunk://#diff-cdc973a7ce76492681bec8c5b86db655f18d78e6daabb1dade77685add03894aR130-R170): Added unit tests for the `clean` method, including scenarios where the validation results file exists and where it does not.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any screenshots that are relevant. -->
- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-1902978]: https://snowflakecomputing.atlassian.net/browse/SNOW-1902978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ