### PR TITLE
SNOW-1797964: Fix Code scanning issues

### DIFF
--- a/.github/workflows/collectors-use-tests_all.yml
+++ b/.github/workflows/collectors-use-tests_all.yml
@@ -171,7 +171,7 @@ jobs:
           }
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"

--- a/.github/workflows/configuration-use-tests_all.yml
+++ b/.github/workflows/configuration-use-tests_all.yml
@@ -172,7 +172,7 @@ jobs:
           }
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"

--- a/.github/workflows/hypothesis-use-tests_all.yml
+++ b/.github/workflows/hypothesis-use-tests_all.yml
@@ -95,7 +95,7 @@ jobs:
           Write-Output "Long paths have been enabled."
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"

--- a/.github/workflows/snowpark-checkpoints-all-demos.yml
+++ b/.github/workflows/snowpark-checkpoints-all-demos.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"

--- a/.github/workflows/snowpark-checkpoints-all-tests.yml
+++ b/.github/workflows/snowpark-checkpoints-all-tests.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"

--- a/.github/workflows/validators-use-tests_all.yml
+++ b/.github/workflows/validators-use-tests_all.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: ./snowpark-checkpoints-validators
 
       - name: Set up Snowflake CLI
-        uses: Snowflake-Labs/snowflake-cli-action@main
+        uses: Snowflake-Labs/snowflake-cli-action@a0d3f3a90914a6a91e6537cc6fde98ebe27e17be
         with:
           cli-version: ${{ matrix.snow_cli_version }}
           default-config-file-path: ".github/config/config.toml"


### PR DESCRIPTION
### Motivation & Context

JIRA: SNOW-1797964

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link the issue here. -->

### Description
Fixed Issues related with Code scanning and Security overview


<img width="982" alt="image" src="https://github.com/user-attachments/assets/d307301f-5f7b-4873-8821-314ace173d84" />


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any screenshots that are relevant. -->

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [X] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [X] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

