### PR TITLE
SNOW-2060757 Enhance telemetry handling for stored procedures

### DIFF
--- a/snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py
+++ b/snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py
@@ -19,19 +19,35 @@ from sys import platform
 from typing import Any, Callable, Optional, TypeVar
 from uuid import getnode
 
-from snowflake.connector import (
-    SNOWFLAKE_CONNECTOR_VERSION,
-    time_util,
-)
-from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
-from snowflake.connector.network import SnowflakeRestful
-from snowflake.connector.telemetry import TelemetryClient
+from snowflake.connector.description import PLATFORM as CONNECTOR_PLATFORM
 from snowflake.snowpark import VERSION as SNOWPARK_VERSION
 from snowflake.snowpark import dataframe as snowpark_dataframe
 from snowflake.snowpark.session import Session
 from snowflake.snowpark_checkpoints_collector.io_utils.io_file_manager import (
     get_io_file_manager,
 )
+
+
+try:
+    """
+    The following imports are used to log telemetry events in the Snowflake Connector.
+    """
+    from snowflake.connector import (
+        SNOWFLAKE_CONNECTOR_VERSION,
+        time_util,
+    )
+    from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
+    from snowflake.connector.network import SnowflakeRestful
+    from snowflake.connector.telemetry import TelemetryClient
+except Exception:
+    """
+    Set default import values for the Snowflake Connector when using snowpark-checkpoints in stored procedures.
+    """
+    SNOWFLAKE_CONNECTOR_VERSION = ""
+    time_util = None
+    SNOWFLAKE_DIRS = ""
+    SnowflakeRestful = None
+    TelemetryClient = None
 
 
 try:
@@ -488,6 +504,16 @@ def get_load_json(json_schema: str) -> dict:
         raise ValueError(f"Error reading JSON schema file: {e}") from None
 
 
+def _is_in_stored_procedure() -> bool:
+    """Check if the code is running in a stored procedure.
+
+    Returns:
+        bool: True if the code is running in a stored procedure, False otherwise.
+
+    """
+    return CONNECTOR_PLATFORM == "XP"
+
+
 def extract_parameters(
     func: Callable, args: tuple, kwargs: dict, params_list: Optional[list[str]]
 ) -> dict:
@@ -835,7 +861,10 @@ def report_telemetry(
             except Exception as err:
                 func_exception = err
 
-            if os.getenv("SNOWPARK_CHECKPOINTS_TELEMETRY_ENABLED") == "false":
+            if (
+                os.getenv("SNOWPARK_CHECKPOINTS_TELEMETRY_ENABLED") == "false"
+                or _is_in_stored_procedure()
+            ):
                 return result
             telemetry_event = None
             data = None

--- a/snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py
+++ b/snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Optional, TypeVar
 from uuid import getnode
 
 from snowflake.connector.description import PLATFORM as CONNECTOR_PLATFORM
+from snowflake.connector.telemetry import TelemetryClient
 from snowflake.snowpark import VERSION as SNOWPARK_VERSION
 from snowflake.snowpark import dataframe as snowpark_dataframe
 from snowflake.snowpark.session import Session
@@ -38,7 +39,6 @@ try:
     )
     from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
     from snowflake.connector.network import SnowflakeRestful
-    from snowflake.connector.telemetry import TelemetryClient
 except Exception:
     """
     Set default import values for the Snowflake Connector when using snowpark-checkpoints in stored procedures.
@@ -47,7 +47,6 @@ except Exception:
     time_util = None
     SNOWFLAKE_DIRS = ""
     SnowflakeRestful = None
-    TelemetryClient = None
 
 
 try:

--- a/snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py
+++ b/snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Optional, TypeVar
 from uuid import getnode
 
 from snowflake.connector.description import PLATFORM as CONNECTOR_PLATFORM
+from snowflake.connector.telemetry import TelemetryClient
 from snowflake.hypothesis_snowpark.io_utils.io_file_manager import (
     get_io_file_manager,
 )
@@ -49,7 +50,6 @@ try:
     )
     from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
     from snowflake.connector.network import SnowflakeRestful
-    from snowflake.connector.telemetry import TelemetryClient
 except Exception:
     """
     Set default import values for the Snowflake Connector when using snowpark-checkpoints in stored procedures.
@@ -58,7 +58,6 @@ except Exception:
     time_util = None
     SNOWFLAKE_DIRS = ""
     SnowflakeRestful = None
-    TelemetryClient = None
 
 
 try:

--- a/snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py
+++ b/snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py
@@ -30,19 +30,35 @@ from sys import platform
 from typing import Any, Callable, Optional, TypeVar
 from uuid import getnode
 
-from snowflake.connector import (
-    SNOWFLAKE_CONNECTOR_VERSION,
-    time_util,
-)
-from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
-from snowflake.connector.network import SnowflakeRestful
-from snowflake.connector.telemetry import TelemetryClient
+from snowflake.connector.description import PLATFORM as CONNECTOR_PLATFORM
 from snowflake.hypothesis_snowpark.io_utils.io_file_manager import (
     get_io_file_manager,
 )
 from snowflake.snowpark import VERSION as SNOWPARK_VERSION
 from snowflake.snowpark import dataframe as snowpark_dataframe
 from snowflake.snowpark.session import Session
+
+
+try:
+    """
+    The following imports are used to log telemetry events in the Snowflake Connector.
+    """
+    from snowflake.connector import (
+        SNOWFLAKE_CONNECTOR_VERSION,
+        time_util,
+    )
+    from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
+    from snowflake.connector.network import SnowflakeRestful
+    from snowflake.connector.telemetry import TelemetryClient
+except Exception:
+    """
+    Set default import values for the Snowflake Connector when using snowpark-checkpoints in stored procedures.
+    """
+    SNOWFLAKE_CONNECTOR_VERSION = ""
+    time_util = None
+    SNOWFLAKE_DIRS = ""
+    SnowflakeRestful = None
+    TelemetryClient = None
 
 
 try:
@@ -499,6 +515,16 @@ def get_load_json(json_schema: str) -> dict:
         raise ValueError(f"Error reading JSON schema file: {e}") from None
 
 
+def _is_in_stored_procedure() -> bool:
+    """Check if the code is running in a stored procedure.
+
+    Returns:
+        bool: True if the code is running in a stored procedure, False otherwise.
+
+    """
+    return CONNECTOR_PLATFORM == "XP"
+
+
 def extract_parameters(
     func: Callable, args: tuple, kwargs: dict, params_list: Optional[list[str]]
 ) -> dict:
@@ -846,7 +872,10 @@ def report_telemetry(
             except Exception as err:
                 func_exception = err
 
-            if os.getenv("SNOWPARK_CHECKPOINTS_TELEMETRY_ENABLED") == "false":
+            if (
+                os.getenv("SNOWPARK_CHECKPOINTS_TELEMETRY_ENABLED") == "false"
+                or _is_in_stored_procedure()
+            ):
                 return result
             telemetry_event = None
             data = None

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py
@@ -31,6 +31,7 @@ from typing import Any, Callable, Optional, TypeVar
 from uuid import getnode
 
 from snowflake.connector.description import PLATFORM as CONNECTOR_PLATFORM
+from snowflake.connector.telemetry import TelemetryClient
 from snowflake.snowpark import VERSION as SNOWPARK_VERSION
 from snowflake.snowpark import dataframe as snowpark_dataframe
 from snowflake.snowpark.session import Session
@@ -49,7 +50,6 @@ try:
     )
     from snowflake.connector.constants import DIRS as SNOWFLAKE_DIRS
     from snowflake.connector.network import SnowflakeRestful
-    from snowflake.connector.telemetry import TelemetryClient
 except Exception:
     """
     Set default import values for the Snowflake Connector when using snowpark-checkpoints in stored procedures.
@@ -58,7 +58,6 @@ except Exception:
     time_util = None
     SNOWFLAKE_DIRS = ""
     SnowflakeRestful = None
-    TelemetryClient = None
 
 
 try:


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-2060757](https://snowflakecomputing.atlassian.net/browse/SNOW-2060757)

<!--- Why is this change required? What problem does it solve? --> 

<!--- If it fixes an open issue, please link the issue here. -->

### Description
<!--- Describe your changes in detail. Link documentation if applicable. --> This pull request introduces changes across multiple modules to enhance telemetry handling, particularly for scenarios where the code is running in a stored procedure. The updates include conditional imports, a utility function to detect stored procedure execution, and adjustments to telemetry logic to account for this context.

### Telemetry Handling Enhancements:

* **Conditional Imports for Stored Procedures**:
  - Added `try-except` blocks to handle import errors gracefully when running in stored procedures. Default values are assigned to Snowflake Connector components if imports fail. (`snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py` [[1]](diffhunk://#diff-06d5232c2043293dac63182d193c9ff2366c09870dd06abb01ce558631e3479dR22-R50) `snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py` [[2]](diffhunk://#diff-59f6ebbc0d58d771088a5119df4116d434bb5cf8144d1c889d320b69ae78af8dR33-R61) `snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py` [[3]](diffhunk://#diff-187fa0201a0bcab97179709111db26854d7690e487616777f7b4149c9c7759f1R33-R61)

* **Utility Function for Stored Procedure Detection**:
  - Introduced `_is_in_stored_procedure()` to determine if the code is running in a stored procedure by checking the `CONNECTOR_PLATFORM` value. (`snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py` [[1]](diffhunk://#diff-06d5232c2043293dac63182d193c9ff2366c09870dd06abb01ce558631e3479dR507-R516) `snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py` [[2]](diffhunk://#diff-59f6ebbc0d58d771088a5119df4116d434bb5cf8144d1c889d320b69ae78af8dR518-R527) `snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py` [[3]](diffhunk://#diff-187fa0201a0bcab97179709111db26854d7690e487616777f7b4149c9c7759f1R518-R527)

* **Telemetry Logic Adjustments**:
  - Updated telemetry wrappers to disable telemetry when either the `SNOWPARK_CHECKPOINTS_TELEMETRY_ENABLED` environment variable is set to "false" or the code is running in a stored procedure. (`snowpark-checkpoints-collectors/src/snowflake/snowpark_checkpoints_collector/utils/telemetry.py` [[1]](diffhunk://#diff-06d5232c2043293dac63182d193c9ff2366c09870dd06abb01ce558631e3479dL838-R867) `snowpark-checkpoints-hypothesis/src/snowflake/hypothesis_snowpark/telemetry/telemetry.py` [[2]](diffhunk://#diff-59f6ebbc0d58d771088a5119df4116d434bb5cf8144d1c889d320b69ae78af8dL849-R878) `snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/utils/telemetry.py` [[3]](diffhunk://#diff-187fa0201a0bcab97179709111db26854d7690e487616777f7b4149c9c7759f1L849-R878)

* **Notes**:
  - The detection of stored procedure execution is based on the `PLATFORM` value being set to "XP". This value is setted here: [Stored-Proc-Python-Connector](https://github.com/snowflakedb/Stored-Proc-Python-Connector/blob/main/src/snowflake/connector/description.py)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> Manual testing in Snowflake Worksheets using store procedures and python worksheet
<!--- Include any screenshots that are relevant. -->

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.
### Review & Approval Requests
<!--- Use this section to request review and approval from specific individuals. -->
<!--- Include any relevant instructions for each reviewer and approver. -->

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-2060757]: https://snowflakecomputing.atlassian.net/browse/SNOW-2060757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ