### PR TITLE
SNOW-2188145: Handle Null Spark Session In JobContext

### DIFF
--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/job_context.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/job_context.py
@@ -122,7 +122,3 @@ class SnowparkJobContext:
         report_df = session.createDataFrame(df)
         LOGGER.info("Writing pass result to table: '%s'", RESULTS_TABLE)
         report_df.write.mode("append").save_as_table(RESULTS_TABLE)
-
-    def _create_pyspark_session(self) -> SparkSession:
-        LOGGER.info("Creating a PySpark session")
-        return SparkSession.builder.getOrCreate()

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/job_context.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/job_context.py
@@ -51,7 +51,7 @@ class SnowparkJobContext:
     ):
         self.log_results = log_results
         self.job_name = job_name
-        self.spark_session = spark_session or self._create_pyspark_session()
+        self.spark_session = spark_session  # A default pyspark session breaks the workflow on snowflake environments.
         self.snowpark_session = snowpark_session
 
     def _mark_fail(

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/snowpark_sampler.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/snowpark_sampler.py
@@ -131,6 +131,10 @@ class SamplingAdapter:
         pyspark_sample_args = []
         for arg in self.pandas_sample_args:
             if isinstance(arg, pandas.DataFrame):
+                if self.job_context.spark_session is None:
+                    raise ValueError(
+                        "A valid SparkSession must be provided. 'spark_session' cannot be None."
+                    )
                 pyspark_df = self.job_context.spark_session.createDataFrame(arg)
                 pyspark_sample_args.append(pyspark_df)
             else:

--- a/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/snowpark_sampler.py
+++ b/snowpark-checkpoints-validators/src/snowflake/snowpark_checkpoints/snowpark_sampler.py
@@ -132,7 +132,7 @@ class SamplingAdapter:
         for arg in self.pandas_sample_args:
             if isinstance(arg, pandas.DataFrame):
                 if self.job_context.spark_session is None:
-                    raise ValueError(
+                    raise SamplingError(
                         "A valid SparkSession must be provided. 'spark_session' cannot be None."
                     )
                 pyspark_df = self.job_context.spark_session.createDataFrame(arg)

--- a/snowpark-checkpoints-validators/test/unit/test_job_context.py
+++ b/snowpark-checkpoints-validators/test/unit/test_job_context.py
@@ -49,7 +49,7 @@ def test_mark_fail_log_results_disabled(caplog: pytest.LogCaptureFixture):
     assert "Recording of migration results into Snowflake is disabled" in caplog.text
 
 
-def test_job_context_no_spark_session(caplog: pytest.LogCaptureFixture):
+def test_job_context_no_spark_session():
     """Testing job context with no spark session."""
 
     snowpark_session = MagicMock()
@@ -59,7 +59,7 @@ def test_job_context_no_spark_session(caplog: pytest.LogCaptureFixture):
     assert job_context.spark_session == None
 
 
-def test_job_context_with_none_spark_session(caplog: pytest.LogCaptureFixture):
+def test_job_context_with_none_spark_session():
     """Testing job context with none spark session."""
 
     snowpark_session = MagicMock()

--- a/snowpark-checkpoints-validators/test/unit/test_job_context.py
+++ b/snowpark-checkpoints-validators/test/unit/test_job_context.py
@@ -47,3 +47,23 @@ def test_mark_fail_log_results_disabled(caplog: pytest.LogCaptureFixture):
     )
 
     assert "Recording of migration results into Snowflake is disabled" in caplog.text
+
+
+def test_job_context_no_spark_session(caplog: pytest.LogCaptureFixture):
+    """Testing job context with no spark session."""
+
+    snowpark_session = MagicMock()
+    job_context = SnowparkJobContext(snowpark_session)
+
+    assert job_context.snowpark_session == snowpark_session
+    assert job_context.spark_session == None
+
+
+def test_job_context_with_none_spark_session(caplog: pytest.LogCaptureFixture):
+    """Testing job context with none spark session."""
+
+    snowpark_session = MagicMock()
+    job_context = SnowparkJobContext(snowpark_session, spark_session=None)
+
+    assert job_context.snowpark_session == snowpark_session
+    assert job_context.spark_session == None


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-2188145](https://snowflakecomputing.atlassian.net/browse/SNOW-2188145)

Snowflake notebook does not allow spark sessions creation. So having a default spark session in the JobContext breaks the workflow on snowflake environments.

### Description
Default spark session in the JobContext is removed to handle null spark session in the JobContext

### How Has This Been Tested?
Unit tests were added.

### Checklist
<!--- Please put an `x` in all the boxes that apply. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.
### Review & Approval Requests
<!--- Use this section to request review and approval from specific individuals. -->
<!--- Include any relevant instructions for each reviewer and approver. -->

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) instead of tagging a PR as `DO NOT MERGE`.


[SNOW-2188145]: https://snowflakecomputing.atlassian.net/browse/SNOW-2188145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ