### PR TITLE
SNOW-1797964: fix(security): prevent command injection in PR Lint workflow (CASEC-10449)

### DIFF
--- a/.github/workflows/snowpark-checkpoints-pr-lint.yml
+++ b/.github/workflows/snowpark-checkpoints-pr-lint.yml
@@ -27,13 +27,18 @@ jobs:
 
       - name: Check if PR contains github-actions[bot] commits
         id: check_bot
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "Fetching PR base and head refs..."
-          git fetch --no-tags --prune origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }} || true
-          git fetch --no-tags --prune origin ${{ github.event.pull_request.head.ref }}:refs/remotes/origin/${{ github.event.pull_request.head.ref }} || true
+          git fetch --no-tags --prune origin -- "$BASE_REF":refs/remotes/origin/"$BASE_REF" || true
+          git fetch --no-tags --prune origin -- "$HEAD_REF":refs/remotes/origin/"$HEAD_REF" || true
 
           echo "Checking commits in PR for github-actions[bot] authorship..."
-          BOT_COMMITS=$(git log --pretty=format:"%an" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep -c "github-actions\[bot\]" || echo "0")
+          BOT_COMMITS=$(git log --pretty=format:"%an" "$BASE_SHA".."$HEAD_SHA" | grep -c "github-actions\[bot\]" || true)
 
           if [[ "$BOT_COMMITS" -gt 0 ]]; then
             echo "WARNING: Found $BOT_COMMITS commit(s) authored by github-actions[bot]. Bypassing PR lint rules."
@@ -97,14 +102,19 @@ jobs:
 
       - name: Check PR Size
         if: steps.check_bot.outputs.bot_created != 'true'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
-          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "Base SHA: $BASE_SHA"
+          echo "Head SHA: $HEAD_SHA"
 
           echo "Fetching diff between the base and head commits..."
-          git fetch --no-tags --prune --depth=2 origin ${{ github.event.pull_request.base.ref }} || true
+          git fetch --no-tags --prune --depth=2 origin -- "$BASE_REF" || true
 
-          CHANGED_PYFILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '\.py$' | grep -v '/test/' || true)
+          CHANGED_PYFILES=$(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" | grep '\.py$' | grep -v '/test/' || true)
           echo "Changed Python files:" $CHANGED_PYFILES
 
           if [ -z "$CHANGED_PYFILES" ]; then
@@ -123,5 +133,3 @@ jobs:
           fi
 
           echo "PR size check passed successfully."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -10,3 +10,11 @@ ignore:
           metadata and GitHub repository.
         expires: 2027-01-23T00:00:00.000Z
         created: 2026-01-23T00:00:00.000Z
+  'snyk:lic:pip:pyarrow:Unknown':
+    - '*':
+        reason: >-
+          pyarrow uses Apache-2.0 license which is valid. Snyk fails to detect
+          the license in version 23.0.1. The license is clearly stated in the project's
+          metadata and GitHub repository.
+        expires: 2027-03-10T00:00:00.000Z
+        created: 2026-03-10T00:00:00.000Z

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
 test:
   requires:
     - pip
+    - setuptools <82
     - snowflake-snowpark-python==1.26.0
     - snowflake-connector-python
     - pyspark

--- a/snowpark-checkpoints-collectors/pyproject.toml
+++ b/snowpark-checkpoints-collectors/pyproject.toml
@@ -57,7 +57,7 @@ development = [
   "twine==5.1.1",
   "hatchling==1.25.0",
   "pre-commit>=4.0.1",
-  "setuptools>=70.0.0",
+  "setuptools>=78.1.1",
   "pyarrow>=18.0.0",
   "deepdiff>=8.1.1",
   "pyspark>=3.5.0",

--- a/snowpark-checkpoints-collectors/recipe/meta.yaml
+++ b/snowpark-checkpoints-collectors/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
 test:
   requires:
     - pip
+    - setuptools <82
     - snowflake-snowpark-python>=1.23.0
     - snowflake-connector-python
     - pyspark

--- a/snowpark-checkpoints-configuration/pyproject.toml
+++ b/snowpark-checkpoints-configuration/pyproject.toml
@@ -54,7 +54,7 @@ development = [
   "twine==5.1.1",
   "hatchling==1.25.0",
   "pre-commit>=4.0.1",
-  "setuptools>=70.0.0",
+  "setuptools>=78.1.1",
   "pyarrow>=18.0.0",
   "certifi==2025.1.31",
 ]

--- a/snowpark-checkpoints-configuration/recipe/meta.yaml
+++ b/snowpark-checkpoints-configuration/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
 test:
   requires:
     - pip
+    - setuptools <82
     - snowflake-snowpark-python>=1.23.0
     - pandas
     - pydantic

--- a/snowpark-checkpoints-hypothesis/pyproject.toml
+++ b/snowpark-checkpoints-hypothesis/pyproject.toml
@@ -55,7 +55,7 @@ development = [
   "twine==5.1.1",
   "hatchling==1.25.0",
   "pre-commit>=4.0.1",
-  "setuptools>=70.0.0",
+  "setuptools>=78.1.1",
   "deepdiff>=8.1.1",
   "certifi==2025.1.31",
 ]

--- a/snowpark-checkpoints-validators/pyproject.toml
+++ b/snowpark-checkpoints-validators/pyproject.toml
@@ -58,7 +58,7 @@ development = [
   "twine==5.1.1",
   "hatchling==1.25.0",
   "pre-commit>=4.0.1",
-  "setuptools>=70.0.0",
+  "setuptools>=78.1.1",
   "pyarrow>=18.0.0",
   "deepdiff>=8.1.1",
   "pyspark>=3.5.0",

--- a/snowpark-checkpoints-validators/recipe/meta.yaml
+++ b/snowpark-checkpoints-validators/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
 
 test:
   requires:
+    - setuptools <82
     - pydantic
   commands:
     - pip install pandera[io]==0.20.4


### PR DESCRIPTION
### Motivation & Context

JIRA: [SNOW-1797964](https://snowflakecomputing.atlassian.net/browse/SNOW-1797964)
JIRA: [CASEC-10451](https://snowflakecomputing.atlassian.net/browse/CASEC-10451)

The PR Lint workflow (`snowpark-checkpoints-pr-lint.yml`) uses `pull_request_target` trigger and directly interpolates attacker-controlled GitHub event data (`head.ref`, `base.ref`, `base.sha`, `head.sha`) into shell `run:` blocks. A malicious branch name can inject arbitrary shell commands. Additionally, several security-related dependency and CI issues are addressed in this PR.

Ref: HackerOne #3593777

### Description

**1. Command injection hardening** (`.github/workflows/snowpark-checkpoints-pr-lint.yml`)
- Move `github.event.pull_request.{base,head}.{ref,sha}` from direct `${{ }}` shell interpolation to `env:` variables (`BASE_REF`, `HEAD_REF`, `BASE_SHA`, `HEAD_SHA`)
- Quote all variable references in `git fetch`, `git log`, and `git diff` commands
- Add `--` separator before ref arguments to prevent option-injection via branch names starting with `-`
- Fix `BOT_COMMITS` assignment to use `|| true` instead of `|| echo "0"` to avoid duplicated output when `grep -c` returns 0 matches
- Move `GITHUB_TOKEN` env from job-level to step-level for the "Check PR Size" step

**2. Bump setuptools >= 78.1.1 to fix CVE-2025-47273** (`*/pyproject.toml`)
- Path traversal vulnerability in setuptools `PackageIndex` ([GHSA-5rjg-fvgr-3xxf](https://github.com/advisories/GHSA-5rjg-fvgr-3xxf)) was fixed in 78.1.1
- Update minimum version in development dependencies for all 4 subpackages: `snowpark-checkpoints-collectors`, `snowpark-checkpoints-configuration`, `snowpark-checkpoints-hypothesis`, `snowpark-checkpoints-validators`

**3. Ignore pyarrow Unknown license false positive** (`.snyk`)
- Snyk fails to detect the Apache-2.0 license in pyarrow v23.0.1
- Add `snyk:lic:pip:pyarrow:Unknown` ignore rule (same pattern as existing `secretstorage` ignore)

**4. Fix Conda build: add setuptools <82 to test requirements** (`*/recipe/meta.yaml`)
- `snowflake-snowpark-python` imports `pkg_resources` (from setuptools) at import time
- setuptools 82.0.0 (released Feb 8, 2026) [removed `pkg_resources`](https://github.com/pypa/setuptools/issues/5174), breaking Conda package tests
- Add `setuptools <82` as explicit test dependency in all 5 Conda recipes to ensure `pkg_resources` remains available

### How Has This Been Tested?

- All CI checks pass (41/41), including the previously failing **Build Conda Packages** and **Install Conda Packages** jobs
- PR Lint workflow validated against the PR itself (passes successfully)
- Snyk scans pass without pyarrow license false positive
- No functional changes to runtime behavior; all changes are CI/build/security hardening

### Checklist

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Data correction (data quality issue originating from upstream source or dataset)
- [ ] Cleanup and optimization (improvement that does not alter the data returned by a model)
- [ ] Other (please specify)
- [X] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment#Eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
    - Checking this checkbox is mandatory if using the [Accelerated Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/1739456592/Accelerated+Risk+Assessment) to risk assess the changes in this Pull Request.
    - If this change does not meet the bar for low risk without security requirements (as confirmed by the peer reviewers of this pull request) then a [formal Risk Assessment](https://snowflakecomputing.atlassian.net/wiki/spaces/ESP/pages/659818607/Risk+Assessment) must be completed. Please note that a formal Risk Assessment will require you to spend extra time performing a security review for this change. Please account for this extra time earlier rather than later to avoid unnecessary delays in the release process.

### Review & Approval Requests

@sfc-gh-dchaconbarrantes @sfc-gh-mfigueroamontero — please review the security hardening in the PR Lint workflow and the Conda recipe changes.

**Note**: Use GitHub's [draft PR feature](https://github.blog/news-insights/product-news/introducing-draft-pull-requests/) for work-in-progress changes. The repository automatically applies "DO NOT MERGE" labels to draft PRs and removes them when ready for review.